### PR TITLE
a little update to utils/configuration

### DIFF
--- a/utils/configuration.nix
+++ b/utils/configuration.nix
@@ -27,7 +27,9 @@ in {
   networking = {
     hostName = hostname;
     useDHCP = false;  # should be disabled
-    # ...instead enable for individual interfaces:
+    # ...instead enable for individual interfaces e.g.:
+    # interfaces."${physical_interface}".useDHCP = true;
+    # interfaces."${wifi_interface}".useDHCP = true;
   };
   services.xserver = {
     layout = "us";

--- a/utils/configuration.nix
+++ b/utils/configuration.nix
@@ -72,7 +72,7 @@ in {
   programs.slock.enable = true;
   services.clipmenu.enable = true;
   services.xserver.exportConfiguration = true;
-  services.dconf.enable = true;
+  programs.dconf.enable = true;
   services.gvfs.enable = true;
   services.xserver.displayManager = {
     defaultSession = "none+instantwm";


### PR DESCRIPTION
- while installing I found that the `dconf` setting should be under `programs` 
- also I added a little suggestion regarding how to setup interfaces to `useDHCP`, since wifi/physical interfaces variables are not used in other places, I thought this is the intended idea(?)